### PR TITLE
Add repo metadata and LICENSE for public release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 David La Puma
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,16 @@
     "mcp",
     "birding"
   ],
-  "author": "",
+  "author": "David La Puma",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/woodcreeper/birding-buddy-mcp.git"
+  },
+  "homepage": "https://github.com/woodcreeper/birding-buddy-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/woodcreeper/birding-buddy-mcp/issues"
+  },
   "description": "Birding Buddy MCP — AI-powered birding companion with eBird, Macaulay Library, and Xeno-canto",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.28.0",


### PR DESCRIPTION
## Summary
- Fill in `author`, `repository`, `homepage`, and `bugs` fields in package.json
- Add MIT LICENSE file to repo root

## Test plan
- [x] package.json is valid JSON
- [x] All metadata fields point to correct GitHub URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)