### PR TITLE
Fix view_checklist crash on missing hotspot metadata

### DIFF
--- a/src/clients/ebird.ts
+++ b/src/clients/ebird.ts
@@ -94,7 +94,7 @@ export interface ChecklistView {
   subId: string;
   protocolId: string;
   locId: string;
-  loc: {
+  loc?: {
     locId: string;
     name: string;
     latitude: number;

--- a/src/tools/checklists.ts
+++ b/src/tools/checklists.ts
@@ -169,15 +169,18 @@ export function registerChecklistTools(server: McpServer, client: EBirdClient) {
         }
       }
 
-      const locationLine = checklist.loc.isHotspot
-        ? `Location: ${checklist.loc.name} (${checklist.loc.locId}) — https://ebird.org/hotspot/${checklist.loc.locId}`
-        : `Location: ${checklist.loc.name} (${checklist.loc.locId})`;
+      const loc = checklist.loc;
+      const locationLine = loc
+        ? loc.isHotspot
+          ? `Location: ${loc.name} (${loc.locId}) — https://ebird.org/hotspot/${loc.locId}`
+          : `Location: ${loc.name} (${loc.locId})`
+        : `Location: ${checklist.locId}`;
 
       const lines = [
         `Checklist: https://ebird.org/checklist/${checklist.subId}`,
         `Observer: ${checklist.userDisplayName}`,
         locationLine,
-        `${checklist.loc.subnational1Name}, ${checklist.loc.countryName}`,
+        loc ? `${loc.subnational1Name}, ${loc.countryName}` : null,
         `Date: ${checklist.obsDt}`,
         `Protocol: ${checklist.protocolId}`,
         checklist.numObservers ? `Observers: ${checklist.numObservers}` : null,


### PR DESCRIPTION
## Summary
- `view_checklist` crashed with `Cannot read properties of undefined (reading 'isHotspot')` when the eBird API returned a checklist without `loc` metadata (e.g. personal/private locations)
- Made `loc` optional in the `ChecklistView` interface to match actual API behavior
- Added null guards in the handler: falls back to `checklist.locId` for location and skips the region line when `loc` is missing

## Test plan
- [ ] Call `view_checklist` with a checklist at a hotspot — verify hotspot link renders
- [ ] Call `view_checklist` with a checklist lacking `loc` metadata — verify graceful fallback instead of crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)